### PR TITLE
Update swift3 syntax

### DIFF
--- a/GraphQLicious.podspec
+++ b/GraphQLicious.podspec
@@ -25,10 +25,10 @@ Pod::Spec.new do |s|
   s.author           = { "Felix Dietz" => "felix.dietz@weltn24.de" }
   s.source           = { :git => "https://github.com/WeltN24/GraphQLicious.git", :tag => s.version.to_s }
 
-  s.ios.platform = :ios, "9.0"
-  s.osx.platform = :osx, "10.10"
-  s.watchos.platform = :watchos, "2.0"
-  s.tvos.platform = :tvos, "9.0"
+  s.ios.platform = "9.0"
+  s.osx.platform = "10.10"
+  s.watchos.platform = "2.0"
+  s.tvos.platform = "9.0"
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'

--- a/GraphQLicious.podspec
+++ b/GraphQLicious.podspec
@@ -25,11 +25,6 @@ Pod::Spec.new do |s|
   s.author           = { "Felix Dietz" => "felix.dietz@weltn24.de" }
   s.source           = { :git => "https://github.com/WeltN24/GraphQLicious.git", :tag => s.version.to_s }
 
-  s.ios.platform = "9.0"
-  s.osx.platform = "10.10"
-  s.watchos.platform = "2.0"
-  s.tvos.platform = "9.0"
-
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0' 

--- a/GraphQLicious.xcodeproj/project.pbxproj
+++ b/GraphQLicious.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 					};
 					D86C60521CAC20AE002691B9 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 						ProvisioningStyle = Manual;
 					};
 					D86C60661CAC20DA002691B9 = {
@@ -579,6 +580,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltN24.GraphQLiciousTests;
 				PRODUCT_NAME = "GraphQLicious Tests";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -589,6 +591,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = de.weltN24.GraphQLiciousTests;
 				PRODUCT_NAME = "GraphQLicious Tests";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Sources/Helper/String.swift
+++ b/Sources/Helper/String.swift
@@ -22,6 +22,6 @@ extension String {
   }
   
   private func replace(_ string: String, with replacement: String) -> String {
-    return self.replacingOccurrences(of: string, with: replacement, options: NSString.CompareOptions.literalSearch, range: nil)
+    return self.replacingOccurrences(of: string, with: replacement, options: NSString.CompareOptions.literal, range: nil)
   }
 }

--- a/Sources/Mutation/Mutation.swift
+++ b/Sources/Mutation/Mutation.swift
@@ -33,10 +33,10 @@
  ```
  */
 public struct Mutation: Operation {
-  private let alias: String
-  private let request: Request
-  private let fragments: [Fragment]
-  private let queryType: QueryType
+  fileprivate let alias: String
+  fileprivate let request: Request
+  fileprivate let fragments: [Fragment]
+  fileprivate let queryType: QueryType
 
   public init(withAlias alias: String = "", mutatingRequest request: Request, fragments: [Fragment] = []) {
     self.alias = alias

--- a/Sources/Query/Query.swift
+++ b/Sources/Query/Query.swift
@@ -32,10 +32,10 @@
  ```
  */
 public struct Query: Operation {
-  private let alias: String
-  private let requests: [Request]
-  private let fragments: [Fragment]
-  private let queryType: QueryType
+  fileprivate let alias: String
+  fileprivate let requests: [Request]
+  fileprivate let fragments: [Fragment]
+  fileprivate let queryType: QueryType
   
   public init(withAlias alias: String = "", request: Request, fragments: [Fragment] = []) {
     self.init(withAlias: alias, requests: [request], fragments: fragments)


### PR DESCRIPTION
1. Update swift 3 syntax.
2. Update podspec to be able to use the master branch without version.
Here's the corresponding issue discussed: https://github.com/CocoaPods/CocoaPods/issues/5626